### PR TITLE
Remove configuration support for 3 wire mode

### DIFF
--- a/bmp280/bmp280_configuration.py
+++ b/bmp280/bmp280_configuration.py
@@ -41,10 +41,6 @@ class BMP280Configuration:
     STANDBY_TIME_2000_MS = 6
     STANDBY_TIME_4000_MS = 7
 
-    # See datasheet paragraph 4.3.5 Register 0xF5 “config” (page 26)
-    SPI_WIRE_MODE_3 = 1
-    SPI_WIRE_MODE_4 = 0
-
     def __init__(self):
         # Configure the 'weather monitoring' use case (page 14, table 7) as default:
         self._pressure_oversampling: int = BMP280Configuration.PRESSURE_OVERSAMPLING_1X
@@ -52,7 +48,6 @@ class BMP280Configuration:
         self._filter_coefficient: int = BMP280Configuration.FILTER_COEFFICIENT_OFF
         self._power_mode: int = BMP280Configuration.POWER_MODE_FORCED
         self._standby_time: int = BMP280Configuration.STANDBY_TIME_1000_MS  # Has no effect in forced mode
-        self._spi_wire_mode: int = BMP280Configuration.SPI_WIRE_MODE_4
 
     @property
     def ctrl_meas(self):
@@ -63,7 +58,7 @@ class BMP280Configuration:
     @property
     def config(self):
         array = bytearray(1)
-        array[0] = self._standby_time << 5 | self._filter_coefficient << 2 | self._spi_wire_mode
+        array[0] = self._standby_time << 5 | self._filter_coefficient << 2
         return array
 
     @property
@@ -105,11 +100,3 @@ class BMP280Configuration:
     @standby_time.setter
     def standby_time(self, standby_time: int):
         self._standby_time = standby_time
-
-    @property
-    def spi_wire_mode(self) -> int:
-        return self._spi_wire_mode
-
-    @spi_wire_mode.setter
-    def spi_wire_mode(self, spi_wire_mode: int):
-        self._spi_wire_mode = spi_wire_mode


### PR DESCRIPTION
SPI 3 wire mode doesn't seem to be supported by the Pico, so it is removed from the configuration class.